### PR TITLE
cmd and args separately from the fixtures

### DIFF
--- a/test/daemon.js
+++ b/test/daemon.js
@@ -4,31 +4,42 @@ var assert = require('assert'),
 
 describe('undaemon', function () {
   describe('good opts', function () {
-    var options = fixtures.options.good,
-        cmd = fixtures.getCmd('daemon', options),
-        child = spawn(cmd);
+    beforeEach(function() {
+      var options = fixtures.options.good,
+          cmd = fixtures.getCmd('daemon', options);
+
+      this.child = spawn(cmd.cmd, cmd.args);
+    });
+
+    afterEach(function() {
+      this.child.kill();
+    })
     it('should succeed with good options', function () {
       var errors = [];
       
-      child.stderr.on('data', function (data) {
+      this.child.stderr.on('data', function (data) {
         errors.push(data);
       });
 
-      child.on('close', function () {
+      this.child.on('close', function () {
         assert(!errors.length, "Got errors >:(");
       });
     });
   });
   describe('bad opts', function () {
-    var options = fixtures.options.bad,
-        cmd = fixtures.getCmd('daemon', options),
-        child = spawn(cmd);
+    beforeEach(function() {
+      var options = fixtures.options.bad,
+          cmd = fixtures.getCmd('daemon', options);
+      
+      this.child = spawn(cmd.cmd, cmd.args);
+    });
+
     it('should fail', function () {
       var errors = [];
-      child.stderr.on('data', function (data) {
+      this.child.stderr.on('data', function (data) {
         errors.push(data);
       });
-      child.on('close', function () {
+      this.child.on('close', function () {
         assert(errors.length, "Did not throw an error >:(");
       })
     });

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -11,14 +11,16 @@ var path = require('path'),
     };
 
 function getCmd (action, opts) {
-  return [
-    path.normalize(path.join(__dirname, '..', 'bin', 'quilt.js')),
-    action,
-    '-m', 
-    path.resolve(opts.mount),
-    '-r', 
-    opts.remote
-  ].join('\ ');
+    return  {
+        cmd : path.normalize(path.join(__dirname, '..', 'bin', 'quilt.js')),
+        args: [
+            action,
+            '-m', 
+            path.resolve(opts.mount),
+            '-r', 
+            opts.remote
+          ]
+    }
 }
 
 module.exports = {

--- a/test/init.js
+++ b/test/init.js
@@ -7,7 +7,7 @@ describe('Quilt', function () {
   describe('good opts', function () {
     var options = fixtures.options.good,
         cmd = fixtures.getCmd('init', options),
-        child = spawn(cmd),
+        child = spawn(cmd.cmd, cmd.args),
         db = nano(options.remote);
 
     it('should sync `hello` with the server', function () {

--- a/test/undaemon.js
+++ b/test/undaemon.js
@@ -4,31 +4,45 @@ var assert = require('assert'),
 
 describe('undaemon', function () {
   describe('good opts', function () {
-    var options = fixtures.options.good,
-        cmd = fixtures.getCmd('undaemon', options),
-        child = spawn(cmd);
+
+    beforeEach(function() {
+      var options = fixtures.options.good,
+          cmd = fixtures.getCmd('undaemon', options);
+      this.child = spawn(cmd.cmd, cmd.args);
+    });
+
+    afterEach(function() {
+      this.child.kill();
+    });
+
     it('should succeed with good options', function () {
       var errors = [];
       
-      child.stderr.on('data', function (data) {
+      this.child.stderr.on('data', function (data) {
         errors.push(data);
       });
 
-      child.on('close', function () {
+      this.child.on('close', function () {
         assert(!errors.length, "Got errors >:(");
       });
     });
   });
   describe('bad opts', function () {
-    var options = fixtures.options.bad,
-        cmd = fixtures.getCmd('undaemon', options),
-        child = spawn(cmd);
+    beforeEach(function() {
+      var options = fixtures.options.bad,
+          cmd = fixtures.getCmd('undaemon', options);
+
+      this.child = spawn(cmd.cmd, cmd.args);
+    });
+
+
     it('should fail', function () {
       var errors = [];
-      child.stderr.on('data', function (data) {
+      this.child.stderr.on('data', function (data) {
         errors.push(data);
       });
-      child.on('close', function () {
+
+      this.child.on('close', function () {
         assert(errors.length, "Did not throw an error >:(");
       })
     });


### PR DESCRIPTION
Refactored tests to use beforeEach and afterEach to do cleanup on the processes (i.e. kill them)
